### PR TITLE
Fix review follow-ups: pallet terminology, date validation, tx docs, and integration tests

### DIFF
--- a/tenebrio_farm/backend/app/routers/ui.py
+++ b/tenebrio_farm/backend/app/routers/ui.py
@@ -168,11 +168,11 @@ def ui_rooms_batch_action(
     db: Session = Depends(get_db),
 ):
     if not pallet_ids:
-        return RedirectResponse(url="/ui/rooms?error=No has seleccionado palets", status_code=303)
+        return RedirectResponse(url="/ui/rooms?error=No has seleccionado pallets", status_code=303)
 
     pallets = db.query(models.Pallet).filter(models.Pallet.id.in_(pallet_ids)).all()
     if not pallets:
-        return RedirectResponse(url="/ui/rooms?error=Palets no encontrados", status_code=303)
+        return RedirectResponse(url="/ui/rooms?error=Pallets no encontrados", status_code=303)
 
     if action == "status":
         allowed = {"active", "cleaning", "quarantine", "disabled", "empty"}
@@ -182,7 +182,7 @@ def ui_rooms_batch_action(
             with smart_begin(db):
                 for p in pallets:
                     p.status = new_status
-            return RedirectResponse(url=f"/ui/rooms?ok=Estado actualizado en {len(pallets)} palets", status_code=303)
+            return RedirectResponse(url=f"/ui/rooms?ok=Estado actualizado en {len(pallets)} pallets", status_code=303)
         except Exception as e:
             return RedirectResponse(
                 url="/ui/rooms?error=" + quote(f"Falló status batch: {type(e).__name__}: {e}"),
@@ -211,7 +211,7 @@ def ui_rooms_batch_action(
                     )
                     p.room_id = move_to_room_id
 
-            return RedirectResponse(url=f"/ui/rooms?ok=Movidos (o ya estaban) {len(pallets)} palets", status_code=303)
+            return RedirectResponse(url=f"/ui/rooms?ok=Movidos (o ya estaban) {len(pallets)} pallets", status_code=303)
         except Exception as e:
             return RedirectResponse(
                 url="/ui/rooms?error=" + quote(f"Falló move batch: {type(e).__name__}: {e}"),
@@ -277,7 +277,7 @@ def ui_rooms_batch_action(
                     crud.add_stock_move(db, sm, commit=False)
                     created += 1
 
-            return RedirectResponse(url=f"/ui/rooms?ok=Alimentados {created} palets (solo activos)", status_code=303)
+            return RedirectResponse(url=f"/ui/rooms?ok=Alimentados {created} pallets (solo activos)", status_code=303)
         except Exception as e:
             return RedirectResponse(
                 url="/ui/rooms?error=" + quote(f"Falló feed batch: {type(e).__name__}: {e}"),
@@ -317,7 +317,7 @@ def ui_rooms_batch_action(
                     crud.add_stock_move(db, sm, commit=False)
                     created += 1
 
-            return RedirectResponse(url=f"/ui/rooms?ok=Cribados {created} palets", status_code=303)
+            return RedirectResponse(url=f"/ui/rooms?ok=Cribados {created} pallets", status_code=303)
         except Exception as e:
             return RedirectResponse(
                 url="/ui/rooms?error=" + quote(f"Falló sieve batch: {type(e).__name__}: {e}"),
@@ -417,7 +417,7 @@ def ui_pallet_detail(pallet_id: str, request: Request, db: Session = Depends(get
 
     stock_feed = [{"item": it, "qty": crud.get_stock_qty(db, it.id)} for it in items_feed]
 
-    # NUEVO: Registro PRO (ProductionTask) vinculado a este palet
+    # NUEVO: Registro PRO (ProductionTask) vinculado a este pallet
     pro_tasks = (
         db.query(ProductionTask)
         .filter(ProductionTask.pallet_id == pallet_id)
@@ -591,7 +591,7 @@ def ui_create_pallet(
 ):
     code = code.strip().upper()
     if not code:
-        return RedirectResponse(url="/ui?error=Código de palet vacío", status_code=303)
+        return RedirectResponse(url="/ui?error=Código de pallet vacío", status_code=303)
     if tray_count <= 0:
         return RedirectResponse(url="/ui?error=El número de bandejas debe ser > 0", status_code=303)
 
@@ -603,7 +603,7 @@ def ui_create_pallet(
 
     dup = db.query(models.Pallet).filter(models.Pallet.code == code).first()
     if dup:
-        return RedirectResponse(url="/ui?error=Ya existe ese código de palet", status_code=303)
+        return RedirectResponse(url="/ui?error=Ya existe ese código de pallet", status_code=303)
 
     p = models.Pallet(
         room_id=room_id,
@@ -615,7 +615,7 @@ def ui_create_pallet(
     )
     db.add(p)
     db.commit()
-    return RedirectResponse(url="/ui?ok=Palet creado", status_code=303)
+    return RedirectResponse(url="/ui?ok=Pallet creado", status_code=303)
 
 
 @router.post("/ui/pallets/move")
@@ -634,7 +634,7 @@ def ui_move_pallet(
         return RedirectResponse(url="/ui?error=Sala destino no encontrada", status_code=303)
 
     if pallet.room_id == to_room_id:
-        return RedirectResponse(url="/ui?error=El palet ya está en esa sala", status_code=303)
+        return RedirectResponse(url="/ui?error=El pallet ya está en esa sala", status_code=303)
 
     move = models.PalletMove(
         pallet_id=pallet.id,
@@ -648,11 +648,11 @@ def ui_move_pallet(
             pallet.room_id = to_room_id
     except Exception as e:
         return RedirectResponse(
-            url=f"/ui/pallet/{pallet.id}?error=" + quote(f"Falló mover palet: {type(e).__name__}: {e}"),
+            url=f"/ui/pallet/{pallet.id}?error=" + quote(f"Falló mover pallet: {type(e).__name__}: {e}"),
             status_code=303,
         )
 
-    return RedirectResponse(url=f"/ui/pallet/{pallet.id}?ok=Palet movido de sala", status_code=303)
+    return RedirectResponse(url=f"/ui/pallet/{pallet.id}?ok=Pallet movido de sala", status_code=303)
 
 
 @router.post("/ui/pallets/status")

--- a/tenebrio_farm/backend/app/templates/history.html
+++ b/tenebrio_farm/backend/app/templates/history.html
@@ -30,7 +30,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
           <th class="nowrap">Fecha</th>
           <th class="nowrap">Hora</th>
           <th>Tipo Tarea</th>
-          <th>Palet</th>
+          <th>Pallet</th>
           <th>Responsable</th>
           <th class="nowrap">Tiempo</th>
           <th>Alimento 1</th>

--- a/tenebrio_farm/backend/app/templates/index.html
+++ b/tenebrio_farm/backend/app/templates/index.html
@@ -40,7 +40,7 @@
 
       <hr style="border:none;border-top:1px solid #eee;margin:14px 0;">
 
-      <h2 style="margin:0 0 8px;">Crear palet</h2>
+      <h2 style="margin:0 0 8px;">Crear pallet</h2>
       <form method="post" action="/ui/pallets/create">
         <label>Sala</label>
         <select name="room_id" required>
@@ -49,7 +49,7 @@
           {% endfor %}
         </select>
 
-        <label>Código palet</label>
+        <label>Código pallet</label>
         <input name="code" placeholder="Ej: H-001" required />
 
         <label>Nº bandejas</label>
@@ -58,7 +58,7 @@
         <label>Notas</label>
         <input name="notes" placeholder="Opcional" />
 
-        <button type="submit">✅ Crear palet</button>
+        <button type="submit">✅ Crear pallet</button>
       </form>
     </div>
 
@@ -90,7 +90,7 @@
     </div>
 
     <div class="card" style="grid-column: 1 / -1;">
-      <h2 style="margin:0 0 8px;">Palets</h2>
+      <h2 style="margin:0 0 8px;">Pallets</h2>
 
       <form method="get" action="/ui" style="display:flex; gap:10px; flex-wrap:wrap; align-items:end;">
         <div style="flex:1; min-width:220px;">
@@ -133,7 +133,7 @@
       </table>
 
       {% if pallets|length == 0 %}
-        <p class="small">No hay palets con esos filtros.</p>
+        <p class="small">No hay pallets con esos filtros.</p>
       {% endif %}
     </div>
 

--- a/tenebrio_farm/backend/app/templates/pallet.html
+++ b/tenebrio_farm/backend/app/templates/pallet.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block title %}Palet {{ pallet.code }} | Tenebrio Farm{% endblock %}
+{% block title %}Pallet {{ pallet.code }} | Tenebrio Farm{% endblock %}
 {% block head_extra %}
 <style>
 body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
@@ -29,7 +29,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
   
 
   <div class="card">
-    <h1 style="margin:0 0 6px;">Palet {{ pallet.code }}</h1>
+    <h1 style="margin:0 0 6px;">Pallet {{ pallet.code }}</h1>
     <div class="small">
       Sala: <b>{{ room.name if room else pallet.room_id }}</b> |
       Bandejas: <b>{{ pallet.tray_count }}</b> |
@@ -76,7 +76,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
           </select>
           <label>Motivo (opcional)</label>
           <input name="reason" placeholder="Ej: reorganización" />
-          <button type="submit">🚚 Mover palet</button>
+          <button type="submit">🚚 Mover pallet</button>
         </form>
       </div>
 
@@ -121,7 +121,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
   <div class="card">
     <h2 style="margin:0 0 10px;">Registro PRO (ProductionTask)</h2>
     {% if pro_tasks|length == 0 %}
-      <p class="small">Aún no hay tareas PRO registradas para este palet.</p>
+      <p class="small">Aún no hay tareas PRO registradas para este pallet.</p>
     {% else %}
       <table>
         <thead>

--- a/tenebrio_farm/backend/app/templates/production.html
+++ b/tenebrio_farm/backend/app/templates/production.html
@@ -114,7 +114,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
 
   <h1>Registro de Tareas PRO (tipo SELECTOR)</h1>
   <p class="small">
-    Registra una tarea para muchos palets a la vez. Si indicas alimento en kg/bandeja, el sistema calcula el total por palet
+    Registra una tarea para muchos pallets a la vez. Si indicas alimento en kg/bandeja, el sistema calcula el total por pallet
     (kg/bandeja × bandejas) y descuenta stock. Si indicas frass, lo suma a stock.
   </p>
 
@@ -192,12 +192,12 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
         </div>
       </div>
 
-      <button type="submit">✅ Registrar tarea PRO para palets seleccionados</button>
+      <button type="submit">✅ Registrar tarea PRO para pallets seleccionados</button>
     </form>
   </div>
 
   <div class="card">
-    <h2 style="margin:0 0 8px;">Seleccionar palets</h2>
+    <h2 style="margin:0 0 8px;">Seleccionar pallets</h2>
 
     <div class="row">
       <div class="col">
@@ -248,7 +248,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
         </tbody>
       </table>
       {% if pallets|length == 0 %}
-        <p class="small">No hay palets para mostrar.</p>
+        <p class="small">No hay pallets para mostrar.</p>
       {% endif %}
     </div>
 

--- a/tenebrio_farm/backend/app/templates/room.html
+++ b/tenebrio_farm/backend/app/templates/room.html
@@ -77,7 +77,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
   </div>
 
   <div class="card">
-    <h2>📦 Palets en esta sala ({{ pallets|length }})</h2>
+    <h2>📦 Pallets en esta sala ({{ pallets|length }})</h2>
     <table>
       <thead>
         <tr>
@@ -99,7 +99,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
       </tbody>
     </table>
     {% if pallets|length == 0 %}
-      <p class="small">No hay palets en esta sala.</p>
+      <p class="small">No hay pallets en esta sala.</p>
     {% endif %}
   </div>
 

--- a/tenebrio_farm/backend/app/templates/rooms_board.html
+++ b/tenebrio_farm/backend/app/templates/rooms_board.html
@@ -296,7 +296,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
 
   <h1>Vista gráfica por salas (con acciones en lote + alertas)</h1>
   <p class="small">
-    Marca palets con el checkbox y aplica una acción en lote. Hoy: <b>{{ today }}</b>
+    Marca pallets con el checkbox y aplica una acción en lote. Hoy: <b>{{ today }}</b>
   </p>
 
   
@@ -326,7 +326,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
           <option value="status">🏷 Cambiar estado</option>
           <option value="move">🚚 Mover a otra sala</option>
         </select>
-        <p class="small">La acción se aplica solo a los palets marcados.</p>
+        <p class="small">La acción se aplica solo a los pallets marcados.</p>
       </div>
 
       <div class="col" id="panel_status" style="display:none;">
@@ -352,9 +352,9 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
       </div>
 
       <div class="col" id="panel_sieve" style="display:none;">
-        <label>Frass (kg) por palet</label>
+        <label>Frass (kg) por pallet</label>
         <input type="number" step="0.001" min="0" name="sieve_frass_kg" placeholder="Ej: 2.5" />
-        <label>Residuo (kg) (opcional) por palet</label>
+        <label>Residuo (kg) (opcional) por pallet</label>
         <input type="number" step="0.001" min="0" name="sieve_residue_kg" />
         <label>Nota (opcional)</label>
         <input name="sieve_note" placeholder="Ej: cribado semanal" />
@@ -371,7 +371,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
         <label>Modo</label>
         <select name="feed_mode">
           <option value="per_tray" selected>Por bandeja</option>
-          <option value="total">Total palet</option>
+          <option value="total">Total pallet</option>
         </select>
 
         <div class="split">
@@ -380,14 +380,14 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
             <input type="number" step="0.001" min="0" name="feed_qty_per_tray_kg" placeholder="Ej: 0.5" />
           </div>
           <div>
-            <label>kg total palet</label>
+            <label>kg total pallet</label>
             <input type="number" step="0.001" min="0" name="feed_qty_total_kg" placeholder="Ej: 13.0" />
           </div>
         </div>
 
         <label>Nota (opcional)</label>
         <input name="feed_note" placeholder="Ej: ración diaria lote" />
-        <p class="small">En “Por bandeja”: total = kg/bandeja × bandejas del palet.</p>
+        <p class="small">En “Por bandeja”: total = kg/bandeja × bandejas del pallet.</p>
       </div>
     </div>
 
@@ -457,7 +457,7 @@ body { font-family: Arial, sans-serif; margin: 20px; background:#f6f7fb; }
             {% endfor %}
 
             {% if (pallets_by_room.get(r.id) or [])|length == 0 %}
-              <div class="small">No hay palets en esta sala.</div>
+              <div class="small">No hay pallets en esta sala.</div>
             {% endif %}
           </div>
         </div>

--- a/tenebrio_farm/backend/app/templates/tasks.html
+++ b/tenebrio_farm/backend/app/templates/tasks.html
@@ -67,7 +67,7 @@
           {% if t.room %}
             Sala: <b>{{ t.room.name }}</b>
           {% elif t.pallet %}
-            Palet:
+            Pallet:
             <a href="/ui/pallet/{{ t.pallet.id }}">
               {{ t.pallet.code }}
             </a>

--- a/tenebrio_farm/backend/tests/test_production_integration.py
+++ b/tenebrio_farm/backend/tests/test_production_integration.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+import sys
+import types
+
+# Stub mínimo para evitar dependencia externa python-multipart en tests.
+multipart_pkg = types.ModuleType("multipart")
+multipart_pkg.__version__ = "0.0-test"
+multipart_sub = types.ModuleType("multipart.multipart")
+
+def parse_options_header(value):
+    return value, {}
+
+multipart_sub.parse_options_header = parse_options_header
+sys.modules.setdefault("multipart", multipart_pkg)
+sys.modules.setdefault("multipart.multipart", multipart_sub)
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from app import crud, models, models_production
+from app.database import Base
+from app.routers.production import ui_production_record
+
+
+class ProductionIntegrationTests(TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = TemporaryDirectory()
+        db_path = Path(self.tmpdir.name) / "test.db"
+        engine = create_engine(f"sqlite:///{db_path}", connect_args={"check_same_thread": False})
+        TestingSessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+        Base.metadata.create_all(bind=engine)
+
+        self.db_session_factory = TestingSessionLocal
+
+        with TestingSessionLocal() as db:
+            room = models.Room(name="Sala 1")
+            db.add(room)
+            db.flush()
+
+            bm = models.BatchMonth(code="2026-01", start_date=date(2026, 1, 1), end_date=date(2026, 1, 31))
+            db.add(bm)
+            db.flush()
+
+            p1 = models.Pallet(code="PAL-001", room_id=room.id, batch_month_id=bm.id, tray_count=10)
+            p2 = models.Pallet(code="PAL-002", room_id=room.id, batch_month_id=bm.id, tray_count=8)
+            db.add_all([p1, p2])
+
+            feed = models.Item(category="feed", name="Pienso A", unit="kg")
+            db.add(feed)
+            db.commit()
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_invalid_day_returns_redirect_error_instead_of_500(self) -> None:
+        with self.db_session_factory() as db:
+            pallet_ids = [p.id for p in db.query(models.Pallet).order_by(models.Pallet.code).all()]
+
+            response = ui_production_record(
+                day="2026-02-31",
+                task_name="Alimentación",
+                responsible="",
+                minutes="0",
+                location="",
+                note="",
+                feed1_item_id="",
+                feed1_qty_per_tray_kg="",
+                feed2_item_id="",
+                feed2_qty_per_tray_kg="",
+                frass_kg="",
+                larvae_total_kg="",
+                pallet_ids=pallet_ids,
+                db=db,
+            )
+
+            self.assertEqual(response.status_code, 303)
+            self.assertIn("error=Fecha%20inv%C3%A1lida", response.headers.get("location", ""))
+            self.assertEqual(db.query(models_production.ProductionTask).count(), 0)
+
+    def test_batch_operation_rolls_back_atomically_on_error(self) -> None:
+        with self.db_session_factory() as db:
+            pallets = db.query(models.Pallet).order_by(models.Pallet.code).all()
+            pallet_ids = [p.id for p in pallets]
+            feed_item = db.query(models.Item).filter(models.Item.category == "feed").first()
+            self.assertIsNotNone(feed_item)
+            feed_item_id = feed_item.id
+            crud.add_stock_move(
+                db,
+                models.StockMove(
+                    item_id=feed_item_id,
+                    move_type="in",
+                    qty_kg=100.0,
+                    ref_type="purchase",
+                    ref_id="init",
+                    note="seed",
+                ),
+            )
+
+        original_add_stock_move = crud.add_stock_move
+        call_count = {"n": 0}
+
+        def failing_add_stock_move(db, move, *, commit=True):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise RuntimeError("forced stock failure")
+            return original_add_stock_move(db, move, commit=commit)
+
+        with self.db_session_factory() as db:
+            with patch("app.routers.production.crud.add_stock_move", side_effect=failing_add_stock_move), patch("builtins.print"):
+                response = ui_production_record(
+                    day="2026-02-10",
+                    task_name="Alimentación",
+                    responsible="",
+                    minutes="0",
+                    location="",
+                    note="",
+                    feed1_item_id=str(feed_item_id),
+                    feed1_qty_per_tray_kg="1",
+                    feed2_item_id="",
+                    feed2_qty_per_tray_kg="",
+                    frass_kg="",
+                    larvae_total_kg="",
+                    pallet_ids=pallet_ids,
+                    db=db,
+                )
+
+            self.assertEqual(response.status_code, 303)
+            self.assertIn("PRO%20fall%C3%B3", response.headers.get("location", ""))
+            self.assertEqual(db.query(models_production.ProductionTask).count(), 0)
+            self.assertEqual(db.query(models.FeedEvent).count(), 0)
+            # Solo queda el movimiento inicial de compra; no deben quedar salidas parciales.
+            self.assertEqual(db.query(models.StockMove).count(), 1)


### PR DESCRIPTION
### Motivation
- Finalizar los cambios solicitados en la revisión: unificar la terminología de palet, asegurar validación robusta de fechas en el registro de producción y añadir pruebas de integración para cubrir escenarios críticos.
- Evitar que entradas inválidas de fecha en `/ui/production/record` provoquen errores 500 y en su lugar devolver un mensaje de error user-facing.
- Aclarar en el código cómo funciona la gestión transaccional (`smart_begin`) para evitar malentendidos sobre rollback/SAVEPOINT.
- Proveer cobertura automática para comprobar rollback atómico en operaciones batch que tocan stock y eventos.

### Description
- Unifiqué la terminología cambiando `palet/palets` a `pallet/pallets` en plantillas y mensajes de UI y en las respuestas de los endpoints relevantes (`app/templates/*`, `app/routers/ui.py`, `app/routers/production.py`).
- En `ui_production_record` se sustituyó el parsing manual de `day` por `dt_date.fromisoformat((day or "").strip())` y se captura `ValueError` para devolver `RedirectResponse(...?error=Fecha inválida...)` en vez de permitir un 500.
- Actualicé la documentación/comentario en el bloque de error para reflejar que `smart_begin()` usa `db.begin()` o `db.begin_nested()` (SAVEPOINT) según el contexto y añadí un `try/except` al inicializador de `Jinja2Templates` para permitir ejecutar tests en entornos sin `jinja2`.
- Añadí pruebas de integración `tests/test_production_integration.py` que comprueban (1) comportamiento ante `day` inválida y (2) rollback atómico ante fallo forzado en `crud.add_stock_move`; la prueba incluye un pequeño stub de `multipart` para evitar depender de `python-multipart` en este entorno.

### Testing
- Ejecuté `python -m unittest discover -s tests -p 'test_*.py' -v` desde `tenebrio_farm/backend` y ambas pruebas de integración pasaron correctamente (2 tests ran, OK).
- Durante la ejecución se utilizó un stub local para `multipart` y se evitó instalar paquetes externos en el entorno de CI local; las pruebas verificaron que no se crean filas parciales en `ProductionTask`, `FeedEvent` ni `StockMove` tras el fallo forzado.
- Se comprobó manualmente que la ruta ahora redirige con `error=Fecha%20inv%C3%A1lida` para entradas de fecha inválidas y que no persisten tareas cuando ocurre un error en mitad del batch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69956eed2c7c83278e5f5141c990eeba)